### PR TITLE
Output extended model with assignment via clasp's generic API

### DIFF
--- a/app/src/main.cc
+++ b/app/src/main.cc
@@ -84,51 +84,9 @@ class App : public Clingo::App, private Clingo::SolveEventHandler {
     }
 
     //! Register options of the theory and optimization related options.
-    void do_register_options(Clingo::Options options) override {
-        using namespace std::string_view_literals;
-        theory_.register_options(options);
-    }
+    void do_register_options(Clingo::Options options) override { theory_.register_options(options); }
     //! Validate options of the theory.
     void do_validate_options() override { theory_.validate_options(); }
-
-    //! Print models with their assignments.
-    void do_print_model(Clingo::ConstModel model, [[maybe_unused]] Clingo::ModelPrinter const &printer) override {
-        auto symbols = model.symbols();
-        std::sort(symbols.begin(), symbols.end());
-        bool comma = false;
-        for (auto const &sym : symbols) {
-            if (!sym.match("__lpx", 2) && !sym.match("__lpx_objective", 2)) {
-                if (comma) {
-                    std::cout << " ";
-                }
-                std::cout << sym;
-                comma = true;
-            }
-        }
-        std::cout << "\nAssignment:\n";
-        comma = false;
-        std::optional<std::pair<Clingo::Symbol, bool>> objective;
-        for (auto const &sym : symbols) {
-            if (sym.match("__lpx", 2) && sym.arguments().back().type() == Clingo::SymbolType::string) {
-                if (comma) {
-                    std::cout << " ";
-                }
-                auto args = sym.arguments();
-                std::cout << args.front() << "=" << args.back().string();
-                comma = true;
-            } else if (sym.match("__lpx_objective", 2) &&
-                       sym.arguments().front().type() == Clingo::SymbolType::string &&
-                       sym.arguments().back().type() == Clingo::SymbolType::number) {
-                auto args = sym.arguments();
-                objective = std::make_pair(args.front(), args.back() == Clingo::Number(1));
-            }
-        }
-        if (objective.has_value()) {
-            std::cout << "\nOptimization: " << objective->first.string() << " ["
-                      << (objective->second ? "bounded" : "unbounded") << "]";
-        }
-        std::cout << std::endl;
-    }
 
   private:
     Clingo::Library lib_;

--- a/lib/c-api/src/clingo-lpx.cc
+++ b/lib/c-api/src/clingo-lpx.cc
@@ -174,7 +174,8 @@ template <typename Value> class LPXPropagatorFacade : public PropagatorFacade {
             ss_.str("");
             ss_ << objective->first;
             symbols.emplace_back(Clingo::Function(
-                lib, "__lpx_objective", {Clingo::String(lib, ss_.view()), Clingo::Number(objective->second ? 1 : 0)}));
+                lib, "__lpx_objective",
+                {Clingo::String(lib, ss_.view()), Clingo::String(lib, objective->second ? "bounded" : "unbounded")}));
         }
         model.extend(symbols);
         prop_.on_model(model);
@@ -476,6 +477,10 @@ struct clingolpx_theory {
                 handle_error(clingo_options_add_flag(options, group.data(), group.size(), name.data(), name.size(),
                                                      desc.data(), desc.size(), &target));
             };
+            auto def = [&](std::string_view name, std::string_view value) {
+                handle_error(
+                    clingo_options_set_default_value(options, name.data(), name.size(), value.data(), value.size()));
+            };
 
             flag("strict", desc_strict, theory->strict);
             flag("propagate-conflicts", desc_conflicts, theory->options.propagate_conflicts);
@@ -483,6 +488,9 @@ struct clingolpx_theory {
             opt("objective", ConfigObjective::desc, c_parse<ConfigObjective>, false, "{local,global[,step]}");
             opt("select", ConfigSelect::desc, c_parse<ConfigSelect>, false, "{none,match,conflict}");
             opt("store", ConfigStore::desc, c_parse<ConfigStore>, false, "{no,partial,total}");
+
+            def("out-assign", "__lpx/2");
+            def("out-cost", "Objective:,__lpx_objective/2:%0 [%1]");
         }
         CLINGO_CATCH;
     }

--- a/lib/python-api/src/clingolpx.cc
+++ b/lib/python-api/src/clingolpx.cc
@@ -52,54 +52,6 @@ class ClingoLPXApp(App):
             self._theory.prepare(control)
             control.solve(on_model=self._theory.on_model, on_stats=self._theory.on_stats)
 
-    def print_model(self, model: Model, default_printer: Callable[[], None]) -> None:
-        """
-        Print the given model in a custom format.
-        """
-        syms = sorted(model.symbols(shown=True))
-        cost = None
-
-        # print symbols
-        comma = False
-        for sym in syms:
-            if not sym.match("__lpx", 2) and not sym.match("__lpx_objective", 2):
-                if comma:
-                    stdout.write(" ")
-                else:
-                    comma = True
-                stdout.write(str(sym))
-
-        # print assignment
-        stdout.write("\nAssignment:\n")
-        comma = False
-        for sym in syms:
-            if sym.match("__lpx", 2):
-                key, val = sym.arguments
-                if comma:
-                    stdout.write(" ")
-                else:
-                    comma = True
-                stdout.write(str(key))
-                stdout.write("=")
-                stdout.write(str(val))
-            if sym.match("__lpx_objective", 2):
-                cost = sym.arguments
-        stdout.write("\n")
-
-        # print costs
-        if cost is not None:
-            val, typ = cost
-            stdout.write("Cost: ")
-            if val.type == SymbolType.String:
-                stdout.write(val.string)
-            else:
-                stdout.write(str(val))
-            bounded = typ.type == SymbolType.Number and typ.number == 1
-            stdout.write(f" [{'bounded' if bounded else 'unbounded'}]")
-            stdout.write("\n")
-
-        stdout.flush()
-
     def register_options(self, options: AppOptions) -> None:
         """
         Register command-line options for the application.


### PR DESCRIPTION
This PR refactors the model output mechanism by removing custom `print_model` implementations in favor of using clasp's generic API for outputting extended models with assignments. The change standardizes output formatting across the C++, Python, and application interfaces.

**Key Changes:**
- Removed custom `print_model` methods from Python API, C++ app, and related code
- Changed objective bounded/unbounded representation from `Number` to `String` for better formatting
- Added default output format configurations using `out-assign` and `out-cost` options

| File | Description |
| ---- | ----------- |
| lib/python-api/src/clingolpx.cc | Removed custom `print_model` method from ClingoLPXApp class |
| lib/c-api/src/clingo-lpx.cc | Changed objective format to use strings, added default output configurations |
| app/src/main.cc | Removed custom `do_print_model` method and simplified `do_register_options` |